### PR TITLE
Codeship: CI_COMMIT_MESSAGE should be CI_MESSAGE

### DIFF
--- a/ci-services/codeship.js
+++ b/ci-services/codeship.js
@@ -32,7 +32,7 @@ function getRepoSlug () {
  */
 function shouldUpdate () {
   let re = /^(chore|fix)\(package\): update [^ ]+ to version.*$/mi
-  return re.test(env.CI_COMMIT_MESSAGE)
+  return re.test(env.CI_MESSAGE)
 }
 
 module.exports = {


### PR DESCRIPTION
Master doesn't work with codeship, so this fixes that by renaming the env variable.